### PR TITLE
Only show KO on Slack if relevant

### DIFF
--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -46,11 +46,14 @@ def slack(url, org, weburl, repos, slackurl, channel):
                     txt += " *%s* -" % (pr.milestone)
                 for label in pr.labels:
                     txt += " *%s* -" % (label['name'])
-                txt += " %s review:%d %s:%d %s:%d %s:%d\n" % \
+                txt += " %s review:%d %s:%d %s:%d" % \
                        (pr.user, pr.nbreview,
                         settings.FEEDBACK_OK['keyword'], pr.feedback_ok,
-                        settings.FEEDBACK_WEAK['keyword'], pr.feedback_weak,
-                        settings.FEEDBACK_KO['keyword'], pr.feedback_ko)
+                        settings.FEEDBACK_WEAK['keyword'], pr.feedback_weak)
+                if pr.feedback_ko > 0:
+                    txt += " %s" % (settings.FEEDBACK_KO['keyword'])
+                txt += "\n"
+
 
 
     payload = {"channel": channel,


### PR DESCRIPTION
In order to improve the visibility on Slack only show the KO keyword
is there is an actual KO on the PR.
Do not show the KO count because one is enough to block the PR.