### PR TITLE
Issue #43: add a column for the lastest activity in a PR (merge to master)

### DIFF
--- a/gm_pr/models.py
+++ b/gm_pr/models.py
@@ -16,7 +16,8 @@
 class Pr:
     """ Simple class wrapper for pr properties
     """
-    def __init__(self, url="", title="", updated_at="", user="", my_open_comment_count=0,
+    def __init__(self, url="", title="", updated_at="", user="", my_open_comment_count=0, last_activity=None,
+    def __init__(self, url="", title="", updated_at="", user="", last_activity=None,
                  repo="", nbreview=0, feedback_ok=0, feedback_weak=0,
                  feedback_ko=0, milestone=None, labels=None,
                  is_old=False):
@@ -25,6 +26,7 @@ class Pr:
         self.updated_at = updated_at
         self.user = user
         self.my_open_comment_count = my_open_comment_count
+        self.last_activity = last_activity
         self.repo = repo
         self.nbreview = nbreview
         self.feedback_ok = feedback_ok

--- a/gm_pr/models.py
+++ b/gm_pr/models.py
@@ -17,7 +17,6 @@ class Pr:
     """ Simple class wrapper for pr properties
     """
     def __init__(self, url="", title="", updated_at="", user="", my_open_comment_count=0, last_activity=None,
-    def __init__(self, url="", title="", updated_at="", user="", last_activity=None,
                  repo="", nbreview=0, feedback_ok=0, feedback_weak=0,
                  feedback_ko=0, milestone=None, labels=None,
                  is_old=False):

--- a/gm_pr/paginablejson.py
+++ b/gm_pr/paginablejson.py
@@ -54,6 +54,10 @@ class PaginableJson:
         self.__idx += 1
         return data[idx]
 
+    def get_last(self):
+        if self.__last_url is not None:
+            self.__fetch_data(self.__last_url)
+        return self.__retrieve_data()
 
     def __init__(self, url):
         self.__url = url

--- a/gm_pr/practivity.py
+++ b/gm_pr/practivity.py
@@ -19,15 +19,30 @@
 * an event (examples include assigning, locking, labeling, milestoning):
   https://developer.github.com/v3/issues/events/
 """
+import functools
 from gm_pr import models, paginablejson, settings
 from django.utils import dateparse
 
 
+@functools.total_ordering
 class PrActivity:
     def __init__(self, date=None, user="", event=""):
         self.date = date
         self.user = user
         self.event = event
+
+    def __eq__(self, other):
+        if other is None: return False
+        if self.date != other.date: return False
+        if self.user != other.user: return False
+        if self.event != other.event: return False
+        return True
+
+    def __lt__(self, other):
+        if other is None: return False
+        # Simplification: just compare the dates.
+        return self.date < other.date
+
 
 # Return a PrActivity for the latest event for the given issue.
 def get_latest_event(issue_url):
@@ -53,10 +68,8 @@ def get_latest_commit(pr_url):
 
 # Return the PrActivity which is the most recent of the two given activities.
 def get_latest_activity(activity1, activity2):
-    if activity1 is None and activity2 is None: return None
     if activity1 is None: return activity2
-    if activity2 is None: return activity1
-    if activity1.date > activity2.date: return activity1
+    if activity1 > activity2: return activity1
     return activity2
 
 

--- a/gm_pr/practivity.py
+++ b/gm_pr/practivity.py
@@ -48,7 +48,7 @@ def get_latest_commit(pr_url):
         return None
     last_commit_json = last_commit_json.get_last()
     return PrActivity(dateparse.parse_datetime(last_commit_json['commit']['committer']['date']),
-                             last_commit_json['committer']['login'],
+                             last_commit_json['commit']['committer']['name'],
                              "committed")
 
 # Return the PrActivity which is the most recent of the two given activities.

--- a/gm_pr/practivity.py
+++ b/gm_pr/practivity.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2015 Genymobile
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Represents an activity on a PR.  An activity may be:
+* a comment
+* a commit
+* an event (examples include assigning, locking, labeling, milestoning):
+  https://developer.github.com/v3/issues/events/
+"""
+from gm_pr import models, paginablejson, settings
+from django.utils import dateparse
+
+
+class PrActivity:
+    def __init__(self, date=None, user="", event=""):
+        self.date = date
+        self.user = user
+        self.event = event
+
+# Return a PrActivity for the latest event for the given issue.
+def get_latest_event(issue_url):
+    event_url = "%s/events?per_page=1" % (issue_url)
+    last_event_json = paginablejson.PaginableJson(event_url)
+    if len(last_event_json) == 0:
+        return None
+    last_event_json = last_event_json.get_last()
+    return PrActivity(dateparse.parse_datetime(last_event_json['created_at']),
+                             last_event_json['actor']['login'],
+                             last_event_json['event'])
+
+# Return a PrActivity for the latest commit for the given PR.
+def get_latest_commit(pr_url):
+    commit_url = "%s/commits?per_page=1" % (pr_url)
+    last_commit_json = paginablejson.PaginableJson(commit_url)
+    if len(last_commit_json) == 0:
+        return None
+    last_commit_json = last_commit_json.get_last()
+    return PrActivity(dateparse.parse_datetime(last_commit_json['commit']['committer']['date']),
+                             last_commit_json['committer']['login'],
+                             "committed")
+
+# Return the PrActivity which is the most recent of the two given activities.
+def get_latest_activity(activity1, activity2):
+    if activity1 is None and activity2 is None: return None
+    if activity1 is None: return activity2
+    if activity2 is None: return activity1
+    if activity1.date > activity2.date: return activity1
+    return activity2
+
+

--- a/gm_pr/practivity.py
+++ b/gm_pr/practivity.py
@@ -26,8 +26,8 @@ from django.utils import dateparse
 
 @functools.total_ordering
 class PrActivity:
-    def __init__(self, date=None, user="", event=""):
-        self.date = date
+    def __init__(self, date_str="", user="", event=""):
+        self.date = dateparse.parse_datetime(date_str)
         self.user = user
         self.event = event
 
@@ -51,7 +51,7 @@ def get_latest_event(issue_url):
     if len(last_event_json) == 0:
         return None
     last_event_json = last_event_json.get_last()
-    return PrActivity(dateparse.parse_datetime(last_event_json['created_at']),
+    return PrActivity(last_event_json['created_at'],
                              last_event_json['actor']['login'],
                              last_event_json['event'])
 
@@ -62,7 +62,7 @@ def get_latest_commit(pr_url):
     if len(last_commit_json) == 0:
         return None
     last_commit_json = last_commit_json.get_last()
-    return PrActivity(dateparse.parse_datetime(last_commit_json['commit']['committer']['date']),
+    return PrActivity(last_commit_json['commit']['committer']['date'],
                              last_commit_json['commit']['committer']['name'],
                              "committed")
 

--- a/gm_pr/practivity.py
+++ b/gm_pr/practivity.py
@@ -20,14 +20,18 @@
   https://developer.github.com/v3/issues/events/
 """
 import functools
-from gm_pr import models, paginablejson, settings
+from gm_pr import paginablejson
 from django.utils import dateparse
+from datetime import datetime
 
 
 @functools.total_ordering
 class PrActivity:
-    def __init__(self, date_str="", user="", event=""):
-        self.date = dateparse.parse_datetime(date_str)
+    def __init__(self, date="", user="", event=""):
+        if isinstance(date, datetime):
+            self.date = date
+        else:
+            self.date = dateparse.parse_datetime(date)
         self.user = user
         self.event = event
 

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -56,8 +56,10 @@ def fetch_data(repo_name, url, org, current_user):
         if json_pr['state'] == 'open':
             conversation_json = paginablejson.PaginableJson(json_pr['comments_url'])
             issue_url = json_pr['issue_url']
-            last_event = practivity.get_latest_event(issue_url)
-            last_commit = practivity.get_latest_commit("%s/%s" %(url, json_pr['number']))
+            last_event = None
+            last_commit = None
+            if "events" in settings.LAST_ACTIVITY_FILTER: last_event = practivity.get_latest_event(issue_url)
+            if "commits" in settings.LAST_ACTIVITY_FILTER: last_commit = practivity.get_latest_commit("%s/%s" %(url, json_pr['number']))
             last_activity = practivity.get_latest_activity(last_event, last_commit)
 
             detail_json = paginablejson.PaginableJson(json_pr['url'])
@@ -93,10 +95,11 @@ def fetch_data(repo_name, url, org, current_user):
             # look for tags and activity only in main conversation and not in "file changed"
             for jcomment in conversation_json:
                 body = jcomment['body']
-                comment_activity = practivity.PrActivity(dateparse.parse_datetime(jcomment['updated_at']),
+                if "comments" in settings.LAST_ACTIVITY_FILTER:
+                    comment_activity = practivity.PrActivity(dateparse.parse_datetime(jcomment['updated_at']),
                                                          jcomment['user']['login'],
                                                          "commented")
-                last_activity = practivity.get_latest_activity(last_activity, comment_activity)
+                    last_activity = practivity.get_latest_activity(last_activity, comment_activity)
                 if re.search(settings.FEEDBACK_OK['keyword'], body):
                     feedback_ok += 1
                 if re.search(settings.FEEDBACK_WEAK['keyword'], body):

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gm_pr import models, paginablejson, settings
+from gm_pr import models, paginablejson, settings, practivity
 from celery import group
 from gm_pr.celery import app
 from operator import attrgetter
@@ -55,13 +55,17 @@ def fetch_data(repo_name, url, org, current_user):
     for json_pr in json_prlist:
         if json_pr['state'] == 'open':
             conversation_json = paginablejson.PaginableJson(json_pr['comments_url'])
+            issue_url = json_pr['issue_url']
+            last_event = practivity.get_latest_event(issue_url)
+            last_commit = practivity.get_latest_commit("%s/%s" %(url, json_pr['number']))
+            last_activity = practivity.get_latest_activity(last_event, last_commit)
+
             detail_json = paginablejson.PaginableJson(json_pr['url'])
             feedback_ok = 0
             feedback_weak = 0
             feedback_ko = 0
             milestone = json_pr['milestone']
-            label_json = paginablejson.PaginableJson("%s/labels" % \
-                                                     json_pr['issue_url'])
+            label_json = paginablejson.PaginableJson("%s/labels" % issue_url)
             labels = list()
             if label_json:
                 for lbl in label_json:
@@ -82,13 +86,17 @@ def fetch_data(repo_name, url, org, current_user):
                             is_old = True
                             break
 
-            # look for tags only in main conversation and not in "file changed"
             if current_user is not None:
                 my_open_comment_count = get_open_comment_count(json_pr['review_comments_url'], current_user)
             else:
                 my_open_comment_count = 0
+            # look for tags and activity only in main conversation and not in "file changed"
             for jcomment in conversation_json:
                 body = jcomment['body']
+                comment_activity = practivity.PrActivity(dateparse.parse_datetime(jcomment['updated_at']),
+                                                         jcomment['user']['login'],
+                                                         "commented")
+                last_activity = practivity.get_latest_activity(last_activity, comment_activity)
                 if re.search(settings.FEEDBACK_OK['keyword'], body):
                     feedback_ok += 1
                 if re.search(settings.FEEDBACK_WEAK['keyword'], body):
@@ -103,6 +111,7 @@ def fetch_data(repo_name, url, org, current_user):
                            updated_at=date,
                            user=json_pr['user']['login'],
                            my_open_comment_count=my_open_comment_count,
+                           last_activity=last_activity,
                            repo=json_pr['base']['repo']['full_name'],
                            nbreview=int(detail_json['comments']) +
                                     int(detail_json['review_comments']),

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -96,7 +96,7 @@ def fetch_data(repo_name, url, org, current_user):
             for jcomment in conversation_json:
                 body = jcomment['body']
                 if "comments" in settings.LAST_ACTIVITY_FILTER:
-                    comment_activity = practivity.PrActivity(dateparse.parse_datetime(jcomment['updated_at']),
+                    comment_activity = practivity.PrActivity(jcomment['updated_at'],
                                                          jcomment['user']['login'],
                                                          "commented")
                     last_activity = practivity.get_latest_activity(last_activity, comment_activity)

--- a/gm_pr/settings_projects.py
+++ b/gm_pr/settings_projects.py
@@ -26,6 +26,14 @@ ORG = "Genymobile"
 # do not change this :-)
 TOP_LEVEL_URL = "https://api.github.com"
 
+# Activities to include in the "Last Activity" column.
+# Possible values are:
+# "comments"
+# "events" (slows page loading)
+# "commits" (slows page loading)
+#LAST_ACTIVITY_FILTER = ("comments", "events", "commits") #slower but provides more information
+LAST_ACTIVITY_FILTER = ("comments")
+
 ##
 # Slack configuration (ignore this section if you do not use slack)
 ##

--- a/gm_pr/templates/pr.html
+++ b/gm_pr/templates/pr.html
@@ -26,6 +26,7 @@ limitations under the License.
         <table class="project">
             <tr>
                 <th>Last update</th>
+                <th>Last Activity</th>
                 <th>Milestone</th>
                 <th>Labels</th>
                 <th>Title</th>
@@ -45,6 +46,11 @@ limitations under the License.
                 {% else %}
                     <td class="last-update">{{pr.updated_at|naturaltime}}</td>
                 {% endif %}
+                <td class="user">
+                    {% if pr.last_activity %}
+                        {{pr.last_activity.user}} ({{pr.last_activity.event}})
+                    {% endif %}
+                </td>
                 <td class="milestone">{% if pr.milestone %}{{pr.milestone}}{% endif %}</td>
                 <td class="label">
                 {% for label in pr.labels %}


### PR DESCRIPTION
This PR adds a new column "Latest Activity" to the web page.

The value will be of the format "user (activity)", where activity is a short (one-word?) description of the activity.

Examples:
```calvarez-geny (committed)```
```CedricCabessa (commented)```

The types of events come from three requests ( :disappointed: ):
* the request on all the comments, which we were doing already
* a request on issue events
* a request on pr commits

The latter two are new requests.  To minimize the impact on performance, I make sure to only ask for the last single result, by adding ```per_page=1``` to the request, and retrieving the ```last``` url only.

Also, there is a setting LAST_ACTIVITY_FILTER, which determines what type of activity will be included in that column.  By default, it's just "comments", which means no additional queries are needed.

Screenshot.  It's the second column:
<img width="1395" alt="d7270c1c-4872-11e5-8dac-7d0f0b486edb" src="https://cloud.githubusercontent.com/assets/1112563/9529273/a33d7022-4cf9-11e5-836b-14612ec52fe8.png">
