### PR TITLE
Issue #5: if a 'login' parameter is specified, user-specific info is displayed (merge to master)

### DIFF
--- a/gm_pr/models.py
+++ b/gm_pr/models.py
@@ -16,7 +16,7 @@
 class Pr:
     """ Simple class wrapper for pr properties
     """
-    def __init__(self, url="", title="", updated_at="", user="", my_open_comments=0,
+    def __init__(self, url="", title="", updated_at="", user="", my_open_comment_count=0,
                  repo="", nbreview=0, feedback_ok=0, feedback_weak=0,
                  feedback_ko=0, milestone=None, labels=None,
                  is_old=False):
@@ -24,7 +24,7 @@ class Pr:
         self.title = title
         self.updated_at = updated_at
         self.user = user
-        self.my_open_comments = my_open_comments
+        self.my_open_comment_count = my_open_comment_count
         self.repo = repo
         self.nbreview = nbreview
         self.feedback_ok = feedback_ok

--- a/gm_pr/models.py
+++ b/gm_pr/models.py
@@ -16,7 +16,7 @@
 class Pr:
     """ Simple class wrapper for pr properties
     """
-    def __init__(self, url="", title="", updated_at="", user="",
+    def __init__(self, url="", title="", updated_at="", user="", my_open_comments=0,
                  repo="", nbreview=0, feedback_ok=0, feedback_weak=0,
                  feedback_ko=0, milestone=None, labels=None,
                  is_old=False):
@@ -24,6 +24,7 @@ class Pr:
         self.title = title
         self.updated_at = updated_at
         self.user = user
+        self.my_open_comments = my_open_comments
         self.repo = repo
         self.nbreview = nbreview
         self.feedback_ok = feedback_ok

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -34,7 +34,7 @@ def is_color_light(rgb_hex_color_string):
     return y > 128
 
 @app.task
-def fetch_data(repo_name, url, org):
+def fetch_data(repo_name, url, org, current_user):
     """ Celery task, call github api
     repo_name -- github repo name
     url -- base url for this repo
@@ -83,6 +83,10 @@ def fetch_data(repo_name, url, org):
                             break
 
             # look for tags only in main conversation and not in "file changed"
+            if current_user is not None:
+                my_open_comments = get_open_comment_count(json_pr['review_comments_url'], current_user)
+            else:
+                my_open_comments = 0
             for jcomment in conversation_json:
                 body = jcomment['body']
                 if re.search(settings.FEEDBACK_OK['keyword'], body):
@@ -98,6 +102,7 @@ def fetch_data(repo_name, url, org):
                            title=json_pr['title'],
                            updated_at=date,
                            user=json_pr['user']['login'],
+                           my_open_comments=my_open_comments,
                            repo=json_pr['base']['repo']['full_name'],
                            nbreview=int(detail_json['comments']) +
                                     int(detail_json['review_comments']),
@@ -116,11 +121,21 @@ def fetch_data(repo_name, url, org):
 
     return repo
 
+# Return the number of non-obsolete review comments posted on the given PR url, by the given user.
+def get_open_comment_count(url, user):
+    open_comments=0
+    review_comments = paginablejson.PaginableJson(url)
+    for review_comment in review_comments:
+        # In obsolote comments, the commit_id != original_commit_id.
+        if review_comment['commit_id'] == review_comment['original_commit_id'] and review_comment['user']['login'] == user:
+            open_comments +=1
+    return open_comments
+
 
 class PrFetcher:
     """ Pr fetc
     """
-    def __init__(self, url, org, repos):
+    def __init__(self, url, org, repos, current_user):
         """
         url -- top level url (eg: https://api.github.com)
         org -- github organisation (eg: Genymobile)
@@ -129,6 +144,7 @@ class PrFetcher:
         self.__url = url
         self.__org = org
         self.__repos = repos
+        self.__current_user = current_user
 
     def get_prs(self):
         """
@@ -137,7 +153,7 @@ class PrFetcher:
         return a list of { 'name' : repo_name, 'pr_list' : pr_list }
         pr_list is a list of models.Pr
         """
-        res = group(fetch_data.s(repo_name, self.__url, self.__org)
+        res = group(fetch_data.s(repo_name, self.__url, self.__org, self.__current_user)
                     for repo_name in self.__repos)()
         data = res.get()
         return [repo for repo in data if repo != None]

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -126,8 +126,8 @@ def get_open_comment_count(url, user):
     open_comments=0
     review_comments = paginablejson.PaginableJson(url)
     for review_comment in review_comments:
-        # In obsolote comments, the commit_id != original_commit_id.
-        if review_comment['commit_id'] == review_comment['original_commit_id'] and review_comment['user']['login'] == user:
+        # In obsolote comments, the position is None
+        if review_comment['position'] is not None and review_comment['user']['login'] == user:
             open_comments +=1
     return open_comments
 

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -84,9 +84,9 @@ def fetch_data(repo_name, url, org, current_user):
 
             # look for tags only in main conversation and not in "file changed"
             if current_user is not None:
-                my_open_comments = get_open_comment_count(json_pr['review_comments_url'], current_user)
+                my_open_comment_count = get_open_comment_count(json_pr['review_comments_url'], current_user)
             else:
-                my_open_comments = 0
+                my_open_comment_count = 0
             for jcomment in conversation_json:
                 body = jcomment['body']
                 if re.search(settings.FEEDBACK_OK['keyword'], body):
@@ -102,7 +102,7 @@ def fetch_data(repo_name, url, org, current_user):
                            title=json_pr['title'],
                            updated_at=date,
                            user=json_pr['user']['login'],
-                           my_open_comments=my_open_comments,
+                           my_open_comment_count=my_open_comment_count,
                            repo=json_pr['base']['repo']['full_name'],
                            nbreview=int(detail_json['comments']) +
                                     int(detail_json['review_comments']),
@@ -123,13 +123,13 @@ def fetch_data(repo_name, url, org, current_user):
 
 # Return the number of non-obsolete review comments posted on the given PR url, by the given user.
 def get_open_comment_count(url, user):
-    open_comments=0
+    open_comment_count=0
     review_comments = paginablejson.PaginableJson(url)
     for review_comment in review_comments:
         # In obsolote comments, the position is None
         if review_comment['position'] is not None and review_comment['user']['login'] == user:
-            open_comments +=1
-    return open_comments
+            open_comment_count +=1
+    return open_comment_count
 
 
 class PrFetcher:

--- a/gm_pr/settings.py
+++ b/gm_pr/settings.py
@@ -123,6 +123,9 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'gm_pr.urls'
 
+from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
+TEMPLATE_CONTEXT_PROCESSORS += ("django.core.context_processors.request",)
+
 TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
     # Always use forward slashes, even on Windows.

--- a/gm_pr/static/gm_pr.css
+++ b/gm_pr/static/gm_pr.css
@@ -108,6 +108,11 @@ td a:hover {
     text-align: center;
     width: 1.5em;
 }
+.my-open-comments{
+    color: black;
+    text-align: center;
+    width: 1.5em;
+}
 .feedback_ok,
 .feedback_weak,
 .feedback_ko {

--- a/gm_pr/static/gm_pr.css
+++ b/gm_pr/static/gm_pr.css
@@ -108,7 +108,7 @@ td a:hover {
     text-align: center;
     width: 1.5em;
 }
-.my-open-comments{
+.my-open-comment-count{
     color: black;
     text-align: center;
     width: 1.5em;

--- a/gm_pr/templates/pr.html
+++ b/gm_pr/templates/pr.html
@@ -55,9 +55,9 @@ limitations under the License.
                 <td class="user">{{pr.user}}</td>
                 <td class="nbrev">{{pr.nbreview}}</td>
                 {% if request.GET.login %}
-                <td class="my-open-comments">
-                    {% if pr.my_open_comments > 0 %}
-                        {{pr.my_open_comments}}
+                <td class="my-open-comment-count">
+                    {% if pr.my_open_comment_count > 0 %}
+                        {{pr.my_open_comment_count}}
                     {% endif %}
                 </td>
                 {% endif %}

--- a/gm_pr/templates/pr.html
+++ b/gm_pr/templates/pr.html
@@ -31,6 +31,9 @@ limitations under the License.
                 <th>Title</th>
                 <th>User</th>
                 <th>Reviews</th>
+                {% if request.GET.login %}
+                <th>My Open Comments</th>
+                {% endif %}
                 <th class="feedback-name">{{feedback_ok|safe}}</th>
                 <th class="feedback-name">{{feedback_weak|safe}}</th>
                 <th class="feedback-name">{{feedback_ko|safe}}</th>
@@ -51,6 +54,13 @@ limitations under the License.
                 <td class="title"><a href="{{pr.url}}">{{pr.title}}</a></td>
                 <td class="user">{{pr.user}}</td>
                 <td class="nbrev">{{pr.nbreview}}</td>
+                {% if request.GET.login %}
+                <td class="my-open-comments">
+                    {% if pr.my_open_comments > 0 %}
+                        {{pr.my_open_comments}}
+                    {% endif %}
+                </td>
+                {% endif %}
                 <td class="feedback_ok">{{pr.feedback_ok}}</td>
                 <td class="feedback_weak">{{pr.feedback_weak}}</td>
                 <td class="feedback_ko">{{pr.feedback_ko}}</td>

--- a/web/views.py
+++ b/web/views.py
@@ -33,7 +33,11 @@ def index(request):
     if repos != None:
         before = time.time()
 
-        prf = PrFetcher(settings.TOP_LEVEL_URL, settings.ORG, repos)
+        current_user = None
+        if 'login' in request.GET:
+            current_user = request.GET['login']
+
+        prf = PrFetcher(settings.TOP_LEVEL_URL, settings.ORG, repos, current_user)
         context = {"title" : "%s PR list" % project,
                    "project_list" : prf.get_prs(),
                    "feedback_ok" : settings.FEEDBACK_OK['name'],


### PR DESCRIPTION
For now, just "My Open Comments" is displayed. If no 'login'
url parameter is specified, then the "My Open Comments" column is
not displayed.

Note, as the issue https://github.com/Genymobile/gm_pr/issues/5 mentions, this is a simple first iteration, where the user id is provided in the request query arguments.  

<img width="1405" alt="7814d7d8-4893-11e5-890b-c1bd395515a4" src="https://cloud.githubusercontent.com/assets/1112563/9529237/70891e88-4cf9-11e5-8516-f15b8646572d.png">
