### PR TITLE
log HTTP errors

### DIFF
--- a/gm_pr/paginablejson.py
+++ b/gm_pr/paginablejson.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json, urllib.request
+import json, urllib.request, urllib.error
+import logging
+
+logger = logging.getLogger('gm_pr')
 
 class PaginableJson:
     """ fetch json data with automatic pagination
@@ -26,7 +29,13 @@ class PaginableJson:
         if self.__last_url == url:
             self.__end = True
 
-        response = urllib.request.urlopen(url)
+        try:
+            response = urllib.request.urlopen(url)
+        except urllib.error.URLError as e:
+            logger.warning("cannot open %s: %s", url, e.reason)
+            self.__data = {}
+            return
+
         charset = response.info().get_content_charset()
         if charset == None:
             charset = 'utf-8'

--- a/gm_pr/settings.py
+++ b/gm_pr/settings.py
@@ -165,23 +165,28 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        }
+    'formatters': {
+        'verbose': {
+            'format': '%(asctime)s %(module)s %(message)s'
+        },
     },
     'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
+        'file': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': 'gm_pr.log',
+            'maxBytes': 10000000,
+            'backupCount': 5,
+            'formatter' : 'verbose',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
     },
     'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
+        'gm_pr': {
+            'handlers': ['file', 'console'],
         },
-    }
+    },
 }


### PR DESCRIPTION
install loggers and catch HTTP error (eg: repo 404) and log them in
"gm_pr.log" and in the console.
This avoid to let gm_pr freeze if a repo does not exists.