### PR TITLE
Build the docker image from the root of this repository:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,12 @@ RUN apt-get install -y \
     apache2 \
     libapache2-mod-wsgi-py3 \
     python3-pip
-ADD commons.txt /tmp/commons.txt
+COPY deploy/commons.txt /tmp/commons.txt
 RUN pip3 install -r /tmp/commons.txt
-ADD gm_pr.conf /etc/apache2/sites-available/gm_pr.conf
+COPY deploy/gm_pr.conf /etc/apache2/sites-available/gm_pr.conf
 RUN a2ensite gm_pr
 
 EXPOSE 80
+COPY . /var/www/gm_pr
 WORKDIR /var/www/gm_pr
 CMD chown -R www-data:www-data . && supervisord -c deploy/supervisord.conf

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ A Dockerfile is available in the "deploy" folder. Building and running the image
 can be done in a few lines:
 
 ```
-cd deploy
 docker build -t gm_pr .
-docker run -v /path/to/gm_pr:/var/www/gm_pr --name gm_pr -p 8000:80 -d gm_pr
+docker run --name gm_pr -p 8000:80 -d gm_pr
+```
+
+You can attach to the docker container in a bash session, to view logs:
+```
+docker exec -i -t gm_pr bash
 ```
 
 Now, you can simply point your browser to http://localhost:8000.


### PR DESCRIPTION
* We copy the repository files to the container, allowing the container's
  file system to be independent of the host
* Also, use the COPY command instead of the ADD command.

(I was told that the COPY command is preferable to ADD, whenever possible)

Pros/cons of this PR:
Con: 
* if you are developping gm_pr, and running your development gm_pr inside a docker container, you'll have to rebuild the docker image whenever you change a file (setting, code, etc).

Pros:
* once you've created your image, it is not dependent on your host filesystem. I'm thinking this will be useful to deploy a completely "contained" container, for example using Marathon (I will be discovering Marathon soon).
* permissions on the files: previously, the owner of the repo files kept getting changed to www-data every time the docker container was run.  This meant that every time I wanted to edit some of my gm_pr repo files after running the container, I had to go and chown again to be able to edit them.  And after this chown, the running container would respond with a 500 error code to requests.  Now, the docker container will no longer access or modify the git repo files on the host.