### PR TITLE
Lighten Slack output to show the most important info

### DIFF
--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -47,15 +47,17 @@ def slack(url, org, weburl, repos, slackurl, channel):
                     txt += " *%s* -" % (pr.milestone)
                 for label in pr.labels:
                     txt += " *%s* -" % (label['name'])
-                txt += " %s review:%d %s:%d %s:%d" % \
-                       (pr.user, pr.nbreview,
-                        settings.FEEDBACK_OK['keyword'], pr.feedback_ok,
-                        settings.FEEDBACK_WEAK['keyword'], pr.feedback_weak)
+                txt += " %s review: %d" % (pr.user, pr.nbreview)
                 if pr.feedback_ko > 0:
                     txt += " %s" % (settings.FEEDBACK_KO['keyword'])
+                elif pr.feedback_ok > 0:
+                    txt += " %s: *%d*" % \
+                        (settings.FEEDBACK_OK['keyword'], pr.feedback_ok)
+                elif pr.feedback_weak > 0:
+                    txt += " %s: %d" % \
+                        (settings.FEEDBACK_WEAK['keyword'], pr.feedback_weak)
+
                 txt += "\n"
-
-
 
     payload = {"channel": channel,
                "username": "genypr",


### PR DESCRIPTION
If a PR is :x: we don't need to know how many people
raised hand or said LGTM.
If there is some LGTM the :hand: are not relevant.
If there is a lot of :hand: and nothing else, it's
a sign same something is going wrong.

As said in our GitHub Workflow we shouldn't use :hand:
this doesn't really means anything and doesn't have
a real weight on the decision to merge. But as some
people are using it right now, we need to keep that
for a while.