### PR TITLE
Dev/review api

### DIFF
--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -49,13 +49,9 @@ def slack(url, org, weburl, repos, slackurl, channel):
                     txt += " *%s* -" % (label['name'])
                 txt += " %s review: %d" % (pr.user, pr.nbreview)
                 if pr.feedback_ko > 0:
-                    txt += " %s" % (settings.FEEDBACK_KO['keyword'])
+                    txt += " Req. Changes"
                 elif pr.feedback_ok > 0:
-                    txt += " %s: *%d*" % \
-                        (settings.FEEDBACK_OK['keyword'], pr.feedback_ok)
-                elif pr.feedback_weak > 0:
-                    txt += " %s: %d" % \
-                        (settings.FEEDBACK_WEAK['keyword'], pr.feedback_weak)
+                    txt += " Approved: *%d*" % pr.feedback_ok
 
                 txt += "\n"
 

--- a/gm_pr/__init__.py
+++ b/gm_pr/__init__.py
@@ -31,6 +31,8 @@ class GithubTokenHttpsHandler(request.HTTPSHandler):
     def https_request(self, req):
         super().https_request(req)
         req.add_header('Authorization', 'token %s' % self.__token)
+        # FIXME: remove when review api is stable (https://developer.github.com/changes/2016-12-16-review-requests-api/)
+        req.add_header('Accept', 'application/vnd.github.black-cat-preview+json')
 
         return req
 

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -63,8 +63,8 @@ def parse_githubdata(data, current_user):
     data { 'repo': genymotion-libauth,
            detail: paginable,
            label: paginable,
-           comment: paginable,
            json: json,
+           comment: paginable, (optional)
            review_comments: paginable, (optional)
            events: paginable, (optional)
            commits: paginable, (optional)
@@ -109,19 +109,14 @@ def parse_githubdata(data, current_user):
         my_open_comment_count = 0
 
     # look for tags and activity only in main conversation and not in "file changed"
-    for jcomment in data['comment']:
-        body = jcomment['body']
-        if "comments" in settings.LAST_ACTIVITY_FILTER:
+    if "comments" in settings.LAST_ACTIVITY_FILTER:
+        for jcomment in data['comment']:
+            body = jcomment['body']
             comment_activity = practivity.PrActivity(jcomment['updated_at'],
                                                      jcomment['user']['login'],
                                                      "commented")
             last_activity = practivity.get_latest_activity(last_activity, comment_activity)
-        if re.search(settings.FEEDBACK_OK['keyword'], body):
-            feedback_ok += 1
-        if re.search(settings.FEEDBACK_WEAK['keyword'], body):
-            feedback_weak += 1
-        if re.search(settings.FEEDBACK_KO['keyword'], body):
-            feedback_ko += 1
+
     if milestone:
         milestone = milestone['title']
 
@@ -167,10 +162,11 @@ def get_urls_for_repo(repo_name, url, org, current_user):
                              # it in the final data response.
                              # see get_tagdata_from_tagurl
                              'url' : json_pr })
-            tagurls.append({ 'repo' : repo_name,
-                             'tag' : 'comment',
-                             'prid' : json_pr['id'],
-                             'url' : json_pr['comments_url'] })
+            if "comments" in settings.LAST_ACTIVITY_FILTER:
+                tagurls.append({ 'repo' : repo_name,
+                                 'tag' : 'comment',
+                                 'prid' : json_pr['id'],
+                                 'url' : json_pr['comments_url'] })
             tagurls.append({ 'repo' : repo_name,
                              'tag' : 'detail',
                              'prid' : json_pr['id'],

--- a/gm_pr/prfetcher.py
+++ b/gm_pr/prfetcher.py
@@ -129,12 +129,8 @@ def parse_githubdata(data, current_user):
                                                     "reviewed")
             last_activity = practivity.get_latest_activity(last_activity, review_activity)
 
-    for user in review_by_user:
-        if review_by_user[user] == "CHANGES_REQUESTED":
-            feedback_ko += 1
-        elif review_by_user[user] == "APPROVED":
-            feedback_ok += 1
-
+    feedback_ok = sum(1 for k,v in review_by_user.items() if v == "APPROVED")
+    feedback_ko = sum(1 for k,v in review_by_user.items() if v == "CHANGES_REQUESTED")
 
     if milestone:
         milestone = milestone['title']

--- a/gm_pr/settings_projects.py
+++ b/gm_pr/settings_projects.py
@@ -40,9 +40,9 @@ TOP_LEVEL_URL = "https://api.github.com"
 # Activities to include in the "Last Activity" column.
 # Possible values are:
 # "reviews"
-# "comments" (extra request)
-# "events" (extra request)
-# "commits" (extra request)
+# "comments" (slower page loading due to extra request)
+# "events" (slower page loading due to extra request)
+# "commits" (slower page loading due to extra request)
 #LAST_ACTIVITY_FILTER = ("comments", "events", "commits") #slower but provides more information
 #LAST_ACTIVITY_FILTER = ("comments") # faster but less information.
 #Ex: env GM_PR_LAST_ACTIVITY_FILTER="comments,events,commits"

--- a/gm_pr/settings_projects.py
+++ b/gm_pr/settings_projects.py
@@ -39,13 +39,14 @@ TOP_LEVEL_URL = "https://api.github.com"
 
 # Activities to include in the "Last Activity" column.
 # Possible values are:
+# "reviews"
 # "comments" (extra request)
 # "events" (extra request)
 # "commits" (extra request)
 #LAST_ACTIVITY_FILTER = ("comments", "events", "commits") #slower but provides more information
 #LAST_ACTIVITY_FILTER = ("comments") # faster but less information.
 #Ex: env GM_PR_LAST_ACTIVITY_FILTER="comments,events,commits"
-LAST_ACTIVITY_FILTER = tuple(os.environ.get("GM_PR_LAST_ACTIVITY_FILTER", "comments").split(","));
+LAST_ACTIVITY_FILTER = tuple(os.environ.get("GM_PR_LAST_ACTIVITY_FILTER", "reviews,comments").split(","));
 
 ##
 # Slack configuration (ignore this section if you do not use slack)

--- a/gm_pr/settings_projects.py
+++ b/gm_pr/settings_projects.py
@@ -39,9 +39,9 @@ TOP_LEVEL_URL = "https://api.github.com"
 
 # Activities to include in the "Last Activity" column.
 # Possible values are:
-# "comments"
-# "events" (slows page loading)
-# "commits" (slows page loading)
+# "comments" (extra request)
+# "events" (extra request)
+# "commits" (extra request)
 #LAST_ACTIVITY_FILTER = ("comments", "events", "commits") #slower but provides more information
 #LAST_ACTIVITY_FILTER = ("comments") # faster but less information.
 #Ex: env GM_PR_LAST_ACTIVITY_FILTER="comments,events,commits"
@@ -67,12 +67,3 @@ OLD_PERIOD = int(os.environ.get("GM_PR_OLD_PERIOD",4))
 # only PRs with one of those labels can be considered as OLD.
 # Use None for "no label"
 OLD_LABELS = ("Needs Reviews", None)
-
-# gm_pr will parse the "conversation" related to each PR to count those symbols
-# The count is available in the web page and can be used to know if your peers
-# agree to merge this PR or not
-# keyword is the text to search for in the github comments, name is the web
-# page column heading
-FEEDBACK_OK = {"keyword": "LGTM", "name" : "LGTM"}
-FEEDBACK_WEAK = {"keyword" : ":hand:", "name" : "&#9995;"}
-FEEDBACK_KO = {"keyword": ":x:", "name" :"&#10007;"}

--- a/requirements/commons.txt
+++ b/requirements/commons.txt
@@ -1,4 +1,5 @@
 Django>=1.8,<1.8.99
+celery>=3.1,<4 # celery 4 is not compatible with django-celery
 django-celery>=3.1,<3.1.99
 SQLAlchemy>=1.0,<1.0.99
 tablib>=0.9,<0.10.99

--- a/web/templates/pr.html
+++ b/web/templates/pr.html
@@ -46,9 +46,8 @@ limitations under the License.
                 {% if request.GET.login %}
                 <th class="alignleft">My Open Comments</th>
                 {% endif %}
-                <th class="aligncenter">{{feedback_ok|safe}}</th>
-                <th class="aligncenter">{{feedback_weak|safe}}</th>
-                <th class="aligncenter">{{feedback_ko|safe}}</th>
+                <th class="aligncenter">Approved</th>
+                <th class="aligncenter">Req. Changes</th>
             </tr>
             </thead>
 
@@ -81,7 +80,6 @@ limitations under the License.
                     </td>
                 {% endif %}
                 <td class="feedback_ok aligncenter">{{pr.feedback_ok}}</td>
-                <td class="aligncenter">{{pr.feedback_weak}}</td>
                 <td class="feedback_ko aligncenter">{{pr.feedback_ko}}</td>
             </tr>
 

--- a/web/views.py
+++ b/web/views.py
@@ -44,10 +44,7 @@ def index(request):
 
         prf = PrFetcher(settings.TOP_LEVEL_URL, settings.ORG, repos, current_user)
         context = {"title" : project,
-                   "projects" : prf.get_prs(),
-                   "feedback_ok" : settings.FEEDBACK_OK['name'],
-                   "feedback_weak" : settings.FEEDBACK_WEAK['name'],
-                   "feedback_ko" : settings.FEEDBACK_KO['name']}
+                   "projects" : prf.get_prs()}
 
         after = time.time()
         logger.debug("page generated in %s sec" % (after - before))


### PR DESCRIPTION
Use the review feature provided by github: https://help.github.com/articles/about-pull-request-reviews/
This replace the previous method based on parsing comments to find keywords (LGTM, :x: , ...).

The "weak review" is not easy to map on the github review system. It could be mapped on the COMMENTED state, but I think the intention is not the same it will be confusing with a simple comment.
This PR remove it.

Better reviewed commit by commit