### PR TITLE
admin repo: use checkbox instead of list

### DIFF
--- a/gm_pr/admin.py
+++ b/gm_pr/admin.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 from django.contrib import admin
+from django.db import models
+from django.forms import CheckboxSelectMultiple
 from gm_pr.models import Project, Repo
 
 from django.contrib.auth.models import Group, User
@@ -45,3 +47,6 @@ class ProjectAdmin(ImportExportModelAdmin):
 @admin.register(Repo)
 class RepoAdmin(ImportExportModelAdmin):
     resource_class = RepoResource
+    formfield_overrides = {
+        models.ManyToManyField: {'widget': CheckboxSelectMultiple},
+    }


### PR DESCRIPTION
When creating/editing repo, you need to select one or many projects this repo
belong to. By default, you have a list (need to hold shift for multiple
selection). This patch replace the list by checkbox
![before](https://cloud.githubusercontent.com/assets/365097/24587326/f3af0d72-17b4-11e7-812e-b3e4c6fa1d36.png)
![after](https://cloud.githubusercontent.com/assets/365097/24587327/f63b8606-17b4-11e7-85c0-ec0417b0261e.png)

