### PR TITLE
Fix Docker file not building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
-RUN apt-get update
-RUN apt-get install -y \
-    celeryd \
-    rabbitmq-server \
-    supervisor \
-    apache2 \
-    libapache2-mod-wsgi-py3 \
-    python3-pip
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apache2 \
+        libapache2-mod-wsgi-py3 \
+        python3-celery \
+        python3-pip \
+        rabbitmq-server \
+        supervisor
+
 COPY requirements/commons.txt /tmp/commons.txt
 RUN pip3 install -r /tmp/commons.txt
 COPY deploy/gm_pr.conf /etc/apache2/sites-available/gm_pr.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY requirements/commons.txt /tmp/commons.txt
 RUN pip3 install -r /tmp/commons.txt
 COPY deploy/gm_pr.conf /etc/apache2/sites-available/gm_pr.conf
 RUN a2ensite gm_pr
+RUN mkdir /var/run/apache2
 
 EXPOSE 80
 COPY . /var/www/gm_pr

--- a/requirements/commons.txt
+++ b/requirements/commons.txt
@@ -2,5 +2,5 @@ Django>=1.8,<1.8.99
 celery>=3.1,<4 # celery 4 is not compatible with django-celery
 django-celery>=3.1,<3.1.99
 SQLAlchemy>=1.0,<1.0.99
-tablib>=0.9,<0.10.99
+tablib>=0.11.4,<0.11.99
 django-import-export>=0.4,<0.4.99


### PR DESCRIPTION
## The problem

The Docker file was not building: installing the Python requirements failed because diff-match-patch failed to build.

## What has been done

- Update to Ubuntu 18.04 (because the Python requirements installed on my local machine)
- Update tablib because the version we used did like Python 3.6
- Fix apache2 not starting because it was missing its runtime dir