### PR TITLE
Fix gm_pr.log file being owned by root at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,11 @@ EXPOSE 80
 COPY . /var/www/gm_pr
 WORKDIR /var/www/gm_pr
 RUN mkdir rw
+
+# Run this before chowning rw because it creates rw/gm_pr.log as root
+# Define dummy values for mandatory settings otherwise python can't import
+# settings.py
+RUN GM_PR_GITHUB_OAUTHTOKEN=dummy GM_PR_ORG=dummy python3 manage.py collectstatic --noinput
+
 RUN chown -R www-data:www-data rw
 CMD supervisord -c deploy/supervisord.conf

--- a/deploy/supervisord.conf
+++ b/deploy/supervisord.conf
@@ -36,12 +36,6 @@ command=python3 manage.py celeryd -l info --concurrency=60
 user=www-data
 priority=50
 
-[program:collect]
-command=python3 manage.py collectstatic --noinput
-user=root
-startsecs=0
-priority=60
-
 [program:makemigrations]
 command=python3 manage.py makemigrations gm_pr
 user=www-data


### PR DESCRIPTION
Startup of gm_pr fails in the Docker because calling `python3 manage.py collectstatic` creates a 0-byte length `gm_pr.log` file owned by root (since collectstatic is run as root). This prevents the rest of gm_pr from writing to the log file.

Since collecting static files is only necessary when static files change, move this step to the creation of the Docker.